### PR TITLE
Refactor mastodon module + add room alias lookup API

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
 name = "mastodon"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "mastodon-bindings",
  "serde",
  "serde_json",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "wit-kv",
  "wit-log",
  "wit-sync-request",
+ "wit-sys",
 ]
 
 [[package]]

--- a/modules/mastodon/Cargo.toml
+++ b/modules/mastodon/Cargo.toml
@@ -9,6 +9,7 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 
 wit-log.workspace = true
+wit-sys.workspace = true
 wit-sync-request.workspace = true
 wit-kv.workspace = true
 
@@ -22,6 +23,7 @@ direct-export = "interface"
 sync-request = "../../wit/sync-request.wit"
 kv = "../../wit/kv.wit"
 log = "../../wit/log.wit"
+sys = "../../wit/sys.wit"
 
 [package.metadata.component.exports]
 interface = "../../wit/trinity-module.wit"

--- a/modules/mastodon/Cargo.toml
+++ b/modules/mastodon/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.66"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 

--- a/modules/wit-sys/src/lib.rs
+++ b/modules/wit-sys/src/lib.rs
@@ -7,3 +7,4 @@ mod wit {
 }
 
 pub use wit::rand_u64;
+pub use wit::resolve_room;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -9,7 +9,10 @@ mod apis;
 
 use std::path::Path;
 
-use matrix_sdk::ruma::{RoomId, UserId};
+use matrix_sdk::{
+    ruma::{RoomId, UserId},
+    Client,
+};
 use wasmtime::AsContextMut;
 
 use crate::{wasm::apis::Apis, ShareableDatabase};
@@ -80,7 +83,7 @@ impl WasmModules {
     /// Create a new collection of wasm modules.
     ///
     /// Must be called from a blocking context.
-    pub fn new(db: ShareableDatabase, modules_path: &Path) -> anyhow::Result<Self> {
+    pub fn new(client: Client, db: ShareableDatabase, modules_path: &Path) -> anyhow::Result<Self> {
         tracing::debug!("setting up wasm context...");
 
         let mut config = wasmtime::Config::new();
@@ -110,7 +113,7 @@ impl WasmModules {
 
             tracing::debug!("creating APIs...");
             let module_state = ModuleState {
-                apis: Apis::new(name.clone(), db.clone())?,
+                apis: Apis::new(client.clone(), name.clone(), db.clone())?,
             };
 
             let entry = store.data_mut().imports.len();

--- a/src/wasm/apis/mod.rs
+++ b/src/wasm/apis/mod.rs
@@ -3,6 +3,8 @@ mod log;
 mod sync_request;
 mod sys;
 
+use matrix_sdk::Client;
+
 use crate::ShareableDatabase;
 
 use self::kv_store::KeyValueStoreApi;
@@ -20,9 +22,9 @@ pub(crate) struct Apis {
 }
 
 impl Apis {
-    pub fn new(module_name: String, db: ShareableDatabase) -> anyhow::Result<Self> {
+    pub fn new(client: Client, module_name: String, db: ShareableDatabase) -> anyhow::Result<Self> {
         Ok(Self {
-            sys: SysApi,
+            sys: SysApi::new(client),
             log: LogApi::new(&module_name),
             sync_request: SyncRequestApi::default(),
             kv_store: KeyValueStoreApi::new(db, &module_name)?,

--- a/src/wasm/apis/sys.rs
+++ b/src/wasm/apis/sys.rs
@@ -1,3 +1,8 @@
+use matrix_sdk::{
+    ruma::{OwnedRoomAliasId, OwnedRoomId},
+    Client,
+};
+
 use crate::wasm::GuestState;
 
 wit_bindgen_host_wasmtime_rust::generate!({
@@ -5,9 +10,15 @@ wit_bindgen_host_wasmtime_rust::generate!({
     name: "sys"
 });
 
-pub(super) struct SysApi;
+pub(super) struct SysApi {
+    client: Client,
+}
 
 impl SysApi {
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+
     pub fn link(
         id: usize,
         linker: &mut wasmtime::component::Linker<GuestState>,
@@ -19,5 +30,32 @@ impl SysApi {
 impl sys::Sys for SysApi {
     fn rand_u64(&mut self) -> anyhow::Result<u64> {
         Ok(rand::random())
+    }
+
+    fn resolve_room(&mut self, room: String) -> anyhow::Result<Result<String, String>> {
+        // Shortcut: if the room is already a room id, return it.
+        if let Ok(room_id) = OwnedRoomId::try_from(room.as_str()) {
+            return Ok(Ok(room_id.to_string()));
+        };
+
+        // Try to resolve the room alias.
+        let room_alias = match OwnedRoomAliasId::try_from(room.as_str()) {
+            Ok(r) => r,
+            Err(err) => return Ok(Err(err.to_string())),
+        };
+
+        let client = self.client.clone();
+        let response =
+            futures::executor::block_on(
+                async move { client.resolve_room_alias(&room_alias).await },
+            );
+
+        match response {
+            Ok(result) => {
+                let room_id = result.room_id.to_string();
+                Ok(Ok(room_id))
+            }
+            Err(err) => Ok(Err(err.to_string())),
+        }
     }
 }

--- a/wit/sys.wit
+++ b/wit/sys.wit
@@ -1,1 +1,3 @@
 rand-u64: func() -> u64
+
+resolve-room: func(room: string) -> result<string, string>


### PR DESCRIPTION
This adds a new method in the `sys` API (we could put it into a new `matrix.wit` API later) that allows to look up a Matrix room ID based on the room alias (in layman words: translates `#trinity:delire.party` to `!IGHgUDMQaIjpiPJKXm:delire.party`), so modules can translate room aliases into internal unique IDs that map to the actual `room_id` parameter they get in `on_msg`. The API call will, at worst, cause one sync query to the Matrix server to do the lookup, but then immediately cache in memory the mapping, so subsequent lookups are very cheap.

With this, I could make per-room configuration for mastodon, and tested it successfully.