### PR TITLE
Pin version of `cargo-component` to a specific revision

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,9 +62,10 @@ jobs:
           args: --all --manifest-path ./modules/Cargo.toml -- --check
 
       - name: Install cargo-component
+        working-directory: ./modules/
         run: |
           rustup update
-          cargo component --version || cargo install --git https://github.com/bytecodealliance/cargo-component
+          cargo component --version || ./install-cargo-component.sh
 
       - name: Check modules
         working-directory: ./modules/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ See for instance the [`uuid`](https://github.com/bnjbvr/trinity/blob/main/module
 and [`horsejs`](https://github.com/bnjbvr/trinity/blob/main/modules/horsejs/src/lib.rs) modules.
 
 Make sure to install [`cargo-component`](https://github.com/bytecodealliance/cargo-component) first
-to be able to build wasm components.
+to be able to build wasm components. We're using a pinned revision of this that can automatically
+be installed with `./modules/install-cargo-component.sh` at the moment; we hope to lift that
+limitation in the future.
 
 Modules can be hot-reloaded, making it trivial to deploy new modules, or replace existing modules
 already running on a server. It is also nice during development iterations on modules. Basically

--- a/modules/README.md
+++ b/modules/README.md
@@ -4,3 +4,6 @@ These are the Trinity modules.
 
 Need to be compiled with the
 [`cargo-component`](https://github.com/bytecodealliance/cargo-component) tool.
+
+Right now, we're pinning the version of `cargo-component` we're using to a specific revision: use
+`./install-cargo-component.sh` from this directory to get the right version.

--- a/modules/install-cargo-component.sh
+++ b/modules/install-cargo-component.sh
@@ -1,0 +1,2 @@
+#/bin/env sh
+cargo install --git https://github.com/bytecodealliance/cargo-component --rev a51dbe43b0962e91731fc67e8075789a5da76644


### PR DESCRIPTION
It has always been very explicitly stated that `cargo-component` and `wit-bindgen` were unstable. Since the beginning of this project, I've had to make one large refactoring of the entire module structure (that was when introducing usage of cargo-component in this repository), and there's been another breakage now in #16 that's related to using the latest version of `cargo-component`, while not upgrading in `wit-bindgen`. I've spent half an hour looking at the changes required in our code base to please `wit-bindgen`, but I'm a bit out of luck at this point, and probably need to get back to the conceptual blackboard, re-reading more about worlds, etc. (Also this would likely be work-related research, so I'd rather do it on my work hours, and I'm currently on holidays :sunglasses:)

In the meanwhile, I'm pinning the version of cargo-component to the one I've successfully used in the past, and introduced an installation script so we can all use the same version and keep this working until I've ported the code base to using worlds.