### PR TITLE
Locally memoize the device id when reconnecting to the matrix server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/bin/main.rs"
 anyhow = "1.0.66"
 dotenvy = "0.15.6"
 futures = "0.3.25"
-matrix-sdk = "0.6.2"
+matrix-sdk = { version = "0.6.2", features = ["e2e-encryption"] }
 notify = "5.0.0"
 rand = "0.8.5"
 redb = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/bin/main.rs"
 anyhow = "1.0.66"
 dotenvy = "0.15.6"
 futures = "0.3.25"
-matrix-sdk = { version = "0.6.2", features = ["e2e-encryption"] }
+matrix-sdk = "0.6.2"
 notify = "5.0.0"
 rand = "0.8.5"
 redb = "0.9.0"

--- a/src/admin_table.rs
+++ b/src/admin_table.rs
@@ -1,0 +1,43 @@
+use redb::ReadableTable;
+
+use crate::ShareableDatabase;
+
+/// Name of the admin table. Can be kept internal.
+const ADMIN_TABLE: redb::TableDefinition<str, [u8]> = redb::TableDefinition::new("@admin");
+
+/// Key for the `device_id` value in the admin table.
+pub const DEVICE_ID_ENTRY: &str = "device_id";
+
+/// Reads a given key in the admin table from the database.
+///
+/// Returns `Ok(None)` if the value wasn't present, `Ok(Some)` if it did exist.
+pub fn read(db: &ShareableDatabase, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+    let txn = db.begin_read()?;
+    let table = match txn.open_table(ADMIN_TABLE) {
+        Ok(table) => table,
+        Err(err) => match err {
+            redb::Error::DatabaseAlreadyOpen
+            | redb::Error::InvalidSavepoint
+            | redb::Error::Corrupted(_)
+            | redb::Error::TableTypeMismatch(_)
+            | redb::Error::DbSizeMismatch { .. }
+            | redb::Error::TableAlreadyOpen(_, _)
+            | redb::Error::OutOfSpace
+            | redb::Error::Io(_)
+            | redb::Error::LockPoisoned(_) => Err(err)?,
+            redb::Error::TableDoesNotExist(_) => return Ok(None),
+        },
+    };
+    Ok(table.get(&key)?.map(|val| val.to_vec()))
+}
+
+/// Writes a given key in the admin table from the database.
+pub fn write(db: &ShareableDatabase, key: &str, value: &[u8]) -> anyhow::Result<()> {
+    let txn = db.begin_write()?;
+    {
+        let mut table = txn.open_table(ADMIN_TABLE)?;
+        table.insert(&key, &value)?;
+    }
+    txn.commit()?;
+    Ok(())
+}

--- a/src/wasm/apis/kv_store.rs
+++ b/src/wasm/apis/kv_store.rs
@@ -9,14 +9,14 @@ wit_bindgen_host_wasmtime_rust::generate!({
 
 pub(super) struct KeyValueStoreApi {
     db: ShareableDatabase,
-    name: String,
+    module_name: String,
 }
 
 impl KeyValueStoreApi {
     pub fn new(db: ShareableDatabase, module_name: &str) -> anyhow::Result<Self> {
         Ok(Self {
             db,
-            name: module_name.to_owned(),
+            module_name: module_name.to_owned(),
         })
     }
 
@@ -30,7 +30,7 @@ impl KeyValueStoreApi {
 
 impl kv::Kv for KeyValueStoreApi {
     fn set(&mut self, key: Vec<u8>, value: Vec<u8>) -> anyhow::Result<()> {
-        let table_def = TableDefinition::<[u8], [u8]>::new(&self.name);
+        let table_def = TableDefinition::<[u8], [u8]>::new(&self.module_name);
         let txn = self.db.begin_write()?;
         {
             let mut table = txn.open_table(table_def)?;
@@ -41,7 +41,7 @@ impl kv::Kv for KeyValueStoreApi {
     }
 
     fn get(&mut self, key: Vec<u8>) -> anyhow::Result<Option<Vec<u8>>> {
-        let table_def = TableDefinition::<[u8], [u8]>::new(&self.name);
+        let table_def = TableDefinition::<[u8], [u8]>::new(&self.module_name);
         let txn = self.db.begin_read()?;
         let table = match txn.open_table(table_def) {
             Ok(table) => table,
@@ -62,7 +62,7 @@ impl kv::Kv for KeyValueStoreApi {
     }
 
     fn remove(&mut self, key: Vec<u8>) -> anyhow::Result<()> {
-        let table_def = TableDefinition::<[u8], [u8]>::new(&self.name);
+        let table_def = TableDefinition::<[u8], [u8]>::new(&self.module_name);
         let txn = self.db.begin_write()?;
         {
             let mut table = txn.open_table(table_def)?;


### PR DESCRIPTION
Should fix #14, according to the nice folks over at #matrix-rust-sdk:matrix.org.