### PR TITLE
feat: add a new linkify module

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -3,6 +3,26 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,10 +47,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -88,6 +122,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "libc"
+version = "0.2.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "linkify"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "linkify-bindings",
+ "regex",
+ "serde",
+ "serde_json",
+ "shlex",
+ "textwrap-macros",
+ "wit-kv",
+ "wit-log",
+]
+
+[[package]]
+name = "linkify-bindings"
+version = "0.1.0"
+dependencies = [
+ "wit-bindgen-guest-rust",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
 name = "openai"
 version = "0.1.0"
 dependencies = [
@@ -143,6 +211,12 @@ version = "0.1.0"
 dependencies = [
  "wit-bindgen-guest-rust",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -190,6 +264,23 @@ checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "ryu"
@@ -245,6 +336,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +356,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975e7e5fec79db404c3f07c9182d1c4450d5e2c68340be6b5a7140f48b276a30"
+dependencies = [
+ "proc-macro-hack",
+ "textwrap-macros-impl",
+]
+
+[[package]]
+name = "textwrap-macros-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32379e128f71c85438e4086388c6321232b64cd7e8560e2c2431d9bfc51fc3cc"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn",
+ "textwrap",
 ]
 
 [[package]]
@@ -269,6 +405,16 @@ name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
+dependencies = [
+ "hashbrown",
+ "regex",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -315,6 +461,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-encoder"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     # Modules
     "./horsejs",
+    "./linkify",
     "./pun",
     "./uuid",
     "./secret",

--- a/modules/linkify/Cargo.toml
+++ b/modules/linkify/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "linkify"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.66"
+regex = "1"
+serde = { version = "1.0.147", features = ["derive"] }
+serde_json = "1.0.87"
+shlex = "1.1.0"
+textwrap-macros = "0.3.0"
+
+wit-kv.workspace = true
+wit-log.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.component]
+direct-export = "interface"
+
+[package.metadata.component.imports]
+kv = "../../wit/kv.wit"
+log = "../../wit/log.wit"
+
+[package.metadata.component.exports]
+interface = "../../wit/trinity-module.wit"
+

--- a/modules/linkify/src/lib.rs
+++ b/modules/linkify/src/lib.rs
@@ -1,0 +1,251 @@
+use anyhow::Context as _;
+use bindings::interface;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use shlex;
+use textwrap_macros::dedent;
+
+use wit_log as log;
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct Rule {
+    name: String,
+    re: String,
+    sub: String,
+}
+
+impl TryFrom<&str> for Rule {
+    type Error = String;
+
+    fn try_from(cmd: &str) -> anyhow::Result<Self, Self::Error> {
+        let words = shlex::split(&cmd).unwrap_or_default();
+        if words.len() != 3 {
+            return Err(String::from("Three inputs expected!"));
+        }
+
+        Ok(Self {
+            name: words[0].clone(),
+            re: words[1].clone(),
+            sub: words[2].clone(),
+        })
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct RoomConfig {
+    enabled_rules: Vec<String>,
+}
+
+struct Component;
+
+impl Component {
+    fn get_rules() -> Vec<Rule> {
+        if let Ok(rules) = wit_kv::get::<_, Vec<Rule>>("rules") {
+            let rules = rules.unwrap_or_default();
+            return rules;
+        }
+        vec![]
+    }
+
+    fn get_room_config(room: &str) -> RoomConfig {
+        if let Ok(rc) = wit_kv::get::<_, RoomConfig>(&format!("room:{}", room)) {
+            let rc = rc.unwrap_or_default();
+            return rc;
+        }
+        RoomConfig {
+            enabled_rules: vec![],
+        }
+    }
+
+    fn replace(msg: &str, rc: RoomConfig) -> Option<String> {
+        for rule in Self::get_rules()
+            .iter()
+            .filter(|&r| rc.enabled_rules.contains(&r.name))
+        {
+            let re = Regex::new(&rule.re).ok()?;
+            if let Some(caps) = re.captures(msg) {
+                let mut dest = String::new();
+                caps.expand(&rule.sub, &mut dest);
+                return Some(dest);
+            }
+        }
+        None
+    }
+
+    fn handle_admin(cmd: &str, _sender: &str, room: &str) -> anyhow::Result<String> {
+        // Format: new NAME RE SUB
+        if let Some(input) = cmd.strip_prefix("new") {
+            let mut rules = Self::get_rules();
+            let rule = match Rule::try_from(input) {
+                Ok(r) => r,
+                Err(e) => return Ok(format!("Error parsing rule: {}", e)),
+            };
+
+            // Don't overwrite existing rules
+            if let Some(_) = rules.iter().find(|&r| r.name == rule.name) {
+                return Ok(format!("Rule '{}' already exists!", &rule.name));
+            }
+
+            // Ensure the regex is valid
+            if Regex::new(&rule.re).is_err() {
+                return Ok(format!("Invalid regex `{}`!", &rule.re));
+            }
+
+            rules.push(rule);
+            let _ = wit_kv::set("rules", &rules);
+            return Ok("Rule has been created!".into());
+        }
+
+        // Format: delete NAME
+        if let Some(cmd) = cmd.strip_prefix("delete") {
+            let mut split = cmd.trim().split_whitespace();
+            let name = split.next().context("missing name")?;
+            let mut rules = Self::get_rules();
+            if let Some(_) = rules.iter().find(|&r| r.name == name) {
+                rules.retain(|r| r.name != name);
+                let _ = wit_kv::set("rules", &rules);
+                return Ok("Rule has been deleted!".into());
+            }
+            return Ok(format!("Rule '{}' not found!", &name));
+        }
+
+        // Format: enable NAME
+        if let Some(cmd) = cmd.strip_prefix("enable") {
+            let mut split = cmd.trim().split_whitespace();
+            let name = split.next().context("missing name")?;
+            let rules = Self::get_rules();
+            if let Some(_) = rules.iter().find(|&r| r.name == name) {
+                let mut rc = Self::get_room_config(room);
+                if rc.enabled_rules.contains(&name.to_string()) {
+                    return Ok(format!("Rule '{}' is already enabled!", &name));
+                }
+                rc.enabled_rules.push(name.to_string());
+                let _ = wit_kv::set(&format!("room:{}", &room), &rc);
+                return Ok(format!("Rule '{}' has been enabled!", &name));
+            }
+            return Ok(format!("Rule '{}' not found!", &name));
+        }
+
+        // Format: disable NAME
+        if let Some(cmd) = cmd.strip_prefix("disable") {
+            let mut split = cmd.trim().split_whitespace();
+            let name = split.next().context("missing name")?;
+            let rules = Self::get_rules();
+            if let Some(_) = rules.iter().find(|&r| r.name == name) {
+                let mut rc = Self::get_room_config(room);
+                if rc.enabled_rules.contains(&name.to_string()) {
+                    rc.enabled_rules.retain(|r| r != &name);
+                    let _ = wit_kv::set(&format!("room:{}", &room), &rc);
+                    return Ok(format!("Rule '{}' has been disabled!", &name));
+                }
+                return Ok(format!("Rule '{}' is already disabled!", &name));
+            }
+            return Ok(format!("Rule '{}' not found!", &name));
+        }
+
+        // Format: list
+        if cmd == "list" {
+            let mut msg = String::new();
+            for rule in Self::get_rules() {
+                msg.push_str(&format!("\n{:?}", &rule));
+            }
+            return Ok(msg);
+        }
+
+        Ok(format!(
+            "Unknown command '{}'!",
+            cmd.split_whitespace().next().unwrap_or("none")
+        ))
+    }
+}
+
+impl interface::Interface for Component {
+    fn init() {
+        let _ = log::set_boxed_logger(Box::new(log::WitLog::new()));
+        log::set_max_level(log::LevelFilter::Trace);
+        log::trace!("Called the init() method \\o/");
+    }
+
+    fn help(topic: Option<String>) -> String {
+        if let Some(topic) = topic {
+            match topic.as_str() {
+                "admin" => dedent!(
+                    r#"
+                    ### Command Overview
+
+                    Available admin commands:
+
+                    - new #NAME #RE #SUB
+                    - delete #NAME
+                    - enable #NAME
+                    - disable #NAME
+                    - list
+
+                    ### Creating and Enabling Rules
+
+                    Rules must first be created using the `new` command, then enabled on a
+                    room by room basis. To create a rule, run
+                    `!admin linkify new <name> <regex> <substitution>`. Where `<name>` is an
+                    identifier to refer to the rule for future use, `<regex>` is a regular expression
+                    to match on text, and `<substitution>` is a string into which the regex capture
+                    groups can be interpolated.
+
+                    For example, to create a new rule which links to a Github issue, run something
+                    like:
+
+                        !admin linkify new issue "(issue ?#?|# ?)([0-9]+)(\\s|$)" https://github.com/bnjbvr/trinity/issues/$2
+
+                    The `$2` will be substituted with the second regex capture group (which is the
+                    issue number in this example). It's also possible to use named capture groups, e.g:
+
+                        !admin linkify new issue "(issue ?#?|# ?)(?P<issue>[0-9]+)(\\s|$)" https://github.com/bnjbvr/trinity/issues/${issue}
+
+                    Then for each room you'd like this rule enabled, run:
+
+                        !admin linkify enable issue
+
+                    Now anytime someone types a string like issue 123 or #123, linkify will respond
+                    with the appropriate URL.
+
+                    The `disable` and `delete` commands take a single `<name>` argument and will
+                    disable the rule, or delete it globally respectively.
+
+            "#
+                )
+                .into(),
+                _ => "Invalid command!".into(),
+            }
+        } else {
+            "Create regex based substition rules per channel! Help topics: admin".to_owned()
+        }
+    }
+
+    fn on_msg(
+        content: String,
+        author_id: String,
+        _author_name: String,
+        room: String,
+    ) -> Vec<interface::Message> {
+        if let Some(content) = Self::replace(&content, Self::get_room_config(&room)) {
+            vec![interface::Message {
+                content,
+                to: author_id,
+            }]
+        } else {
+            vec![]
+        }
+    }
+
+    fn admin(cmd: String, author: String, room: String) -> Vec<interface::Message> {
+        let content = match Self::handle_admin(&cmd, &author, &room) {
+            Ok(resp) => resp,
+            Err(err) => err.to_string(),
+        };
+
+        vec![interface::Message {
+            content,
+            to: author,
+        }]
+    }
+}
+bindings::export!(Component);


### PR DESCRIPTION
I still plan to clean this up a bit and add better help text, but it seems to be working pretty much how I was hoping it would. A couple points:

1. I don't really care if this lives in Trinity core or not, I'm likely going to end up creating a separate module repository at some point anyway so lmk if you'd prefer it live elsewhere. Though I do wonder what your thoughts are on which modules should live directly in Trinity and which shouldn't.
2. I'm not sold on the name because it doesn't really linkify things, it's more of a general replace + reply module. Though I struggle to think of use cases that don't involve creating links.. 