### PR TITLE
Add Docker image (fixes #21)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Build image.
+
+FROM rust:1.68 AS builder
+LABEL maintainer="Benjamin Bouvier <public@benj.me>"
+
+RUN mkdir -p /build/modules
+
+COPY ./Cargo.* /build/
+COPY ./src /build/src
+COPY ./wit /build/wit
+COPY ./modules /build/modules/
+
+# Compile the host.
+WORKDIR /build/src
+RUN cargo build --release
+
+# Install the pinned version of cargo-component.
+WORKDIR /build/modules
+RUN ./install-cargo-component.sh && \
+    rustup component add rustfmt
+RUN cargo component build --release
+
+# Actual image.
+FROM debian:bullseye-slim
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    update-ca-certificates && \
+    mkdir -p /opt/trinity/data && \
+    mkdir -p /opt/trinity/modules/target/wasm32-unknown-unknown/release
+
+COPY --from=builder /build/target/release/trinity /opt/trinity/trinity
+COPY --from=builder \
+    /build/modules/target/wasm32-unknown-unknown/release/*.wasm \
+    /opt/trinity/modules/target/wasm32-unknown-unknown/release
+
+ENV MATRIX_STORE_PATH /opt/trinity/data/cache
+ENV REDB_PATH /opt/trinity/data/db
+
+VOLUME /opt/trinity/data
+
+WORKDIR /opt/trinity
+CMD /opt/trinity/trinity

--- a/README.md
+++ b/README.md
@@ -92,8 +92,12 @@ docker run -e HOMESERVER="matrix.example.com" \
     -e BOT_USER_ID="@trinity:example.com" \
     -e BOT_PWD="hunter2" \
     -e ADMIN_USER_ID="@admin:example.com" \
+    -v /host/path/to/data/directory:/opt/trinity/data
     bnjbvr/trinity
 ```
+
+Data is saved in the `/opt/trinity/data` directory, and it is recommended to make it a volume so as
+to be able to decrypt messages over multiple sessions and so on.
 
 ## Is it any good?
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ ideas, please go ahead :)
 - ask what's the weather in some city, is it going to rain in the next hour, etc.
 - YOUR BILLION DOLLARS IDEA HERE
 
+## Deploy with Docker
+
+First, build the Docker image:
+
+```
+docker build -t bnjbvr/trinity .
+```
+
+Then start it with the right environment variables (see also `.env.example`):
+
+```
+docker run -e HOMESERVER="matrix.example.com" \
+    -e BOT_USER_ID="@trinity:example.com" \
+    -e BOT_PWD="hunter2" \
+    -e ADMIN_USER_ID="@admin:example.com" \
+    bnjbvr/trinity
+```
+
 ## Is it any good?
 
 Yes.


### PR DESCRIPTION
This creates a new Docker image and documents how to set it up, in the README. This should be sufficient to quickly host a new instance, via a bot.