### PR TITLE
Allow to specify multiple paths where to look for wasm modules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
+# URL for the home server, without https:// prefix.
 HOMESERVER="matrix.example.org"
+# Bot account user id.
 BOT_USER_ID=@alice:example.org
+# Bot account password.
 BOT_PWD=hunter2
+# Where should the Matrix store live?
 MATRIX_STORE_PATH=./cache
-REDB_PATH=./example.db
+# Where should some trinity metadata be stored?
+REDB_PATH=./trinity.db
+# Who is the owner/admin user for this bot?
 ADMIN_USER_ID=@bob:example.org
+# Paths to one or multiple paths containing Trinity wasm commands, separated by commas.
+MODULES_PATHS=./modules/target/wasm32-unknown-unknown/release,/other/path/to/modules

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .env
 trinity.db
 cache/
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 .env
+trinity.db
 cache/

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ ideas, please go ahead :)
 
 ## Deploy with Docker
 
-First, build the Docker image:
+If you want, you can use the image published on Docker
+([bnjbvr/trinity](https://hub.docker.com/repository/docker/bnjbvr/trinity)) -- it might be lagging
+behind by a few commits -- or build the Docker image yourself:
 
 ```
 docker build -t bnjbvr/trinity .
@@ -92,12 +94,27 @@ docker run -e HOMESERVER="matrix.example.com" \
     -e BOT_USER_ID="@trinity:example.com" \
     -e BOT_PWD="hunter2" \
     -e ADMIN_USER_ID="@admin:example.com" \
-    -v /host/path/to/data/directory:/opt/trinity/data
-    bnjbvr/trinity
+    -v /host/path/to/data/directory:/opt/trinity/data \
+    -ti bnjbvr/trinity
 ```
 
 Data is saved in the `/opt/trinity/data` directory, and it is recommended to make it a volume so as
 to be able to decrypt messages over multiple sessions and so on.
+
+If you want, you can specify a custom modules directory using the `MODULES_PATHS` environment
+variable and adding another data volume for it. This can be useful for hacking modules only without
+having to compile the host runtime. Here's how you can do that:
+
+```
+docker run -e HOMESERVER="matrix.example.com" \
+    -e BOT_USER_ID="@trinity:example.com" \
+    -e BOT_PWD="hunter2" \
+    -e ADMIN_USER_ID="@admin:example.com" \
+    -e MODULES_PATH="/wasm-modules" \
+    -v /host/path/to/data/directory:/opt/trinity/data \
+    -v /host/path/to/modules:/wasm-modules \
+    -ti bnjbvr/trinity
+```
 
 ## Is it any good?
 

--- a/src/admin_table.rs
+++ b/src/admin_table.rs
@@ -28,7 +28,7 @@ pub fn read(db: &ShareableDatabase, key: &str) -> anyhow::Result<Option<Vec<u8>>
             redb::Error::TableDoesNotExist(_) => return Ok(None),
         },
     };
-    Ok(table.get(&key)?.map(|val| val.to_vec()))
+    Ok(table.get(key)?.map(|val| val.to_vec()))
 }
 
 /// Writes a given key in the admin table from the database.
@@ -36,7 +36,7 @@ pub fn write(db: &ShareableDatabase, key: &str, value: &[u8]) -> anyhow::Result<
     let txn = db.begin_write()?;
     {
         let mut table = txn.open_table(ADMIN_TABLE)?;
-        table.insert(&key, &value)?;
+        table.insert(key, value)?;
     }
     txn.commit()?;
     Ok(())

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,3 @@
-use anyhow;
-use trinity;
-
 async fn real_main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,14 +182,14 @@ fn try_handle_admin<'a>(
     tracing::trace!("trying admin for {content}");
     if let Some(rest) = rest.strip_prefix(' ') {
         let rest = rest.trim();
-        if let Some((module, rest)) = rest.split_once(" ").map(|(l, r)| (l, r.trim())) {
+        if let Some((module, rest)) = rest.split_once(' ').map(|(l, r)| (l, r.trim())) {
             // If the next word resolves to a valid room id use that, otherwise use the
             // current room.
             let (possible_room, rest) = rest
-                .split_once(" ")
+                .split_once(' ')
                 .map_or((rest, ""), |(l, r)| (l, r.trim()));
 
-            let (target_room, rest) = match room_resolver.resolve_room(&possible_room) {
+            let (target_room, rest) = match room_resolver.resolve_room(possible_room) {
                 Ok(Some(resolved_room)) => (resolved_room, rest.to_string()),
                 Ok(None) | Err(_) => (room.to_string(), format!("{} {}", possible_room, rest)),
             };
@@ -251,13 +251,13 @@ fn try_handle_help<'a>(
     } else if let Some(rest) = rest.strip_prefix(' ') {
         let rest = rest.trim();
         let (module, topic) = rest
-            .split_once(" ")
+            .split_once(' ')
             .map(|(l, r)| (l, Some(r.trim())))
             .unwrap_or((rest, None));
         let mut found = None;
         for m in modules {
             if m.name() == module {
-                found = m.help(&mut *store, topic.as_deref()).ok();
+                found = m.help(&mut *store, topic).ok();
                 break;
             }
         }
@@ -321,7 +321,7 @@ async fn on_message(
 
             let (store, modules) = ctx.modules.iter();
 
-            if ev.sender() == &ctx.admin_user_id {
+            if ev.sender() == ctx.admin_user_id {
                 if let Some(admin_messages) = try_handle_admin(
                     &content,
                     &ctx.admin_user_id,
@@ -333,7 +333,7 @@ async fn on_message(
                     tracing::trace!("handled by admin, skipping modules");
                     return admin_messages
                         .into_iter()
-                        .map(|msg| RoomMessageEventContent::text_plain(msg))
+                        .map(RoomMessageEventContent::text_plain)
                         .collect();
                 }
             }

--- a/src/room_resolver.rs
+++ b/src/room_resolver.rs
@@ -20,7 +20,7 @@ impl RoomResolver {
     }
 
     pub fn resolve_room(&mut self, room: &str) -> anyhow::Result<Option<String>> {
-        if !room.starts_with("#") && !room.starts_with("!") {
+        if !room.starts_with('#') && !room.starts_with('!') {
             // This is likely not meant to be a room.
             return Ok(None);
         }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -136,7 +136,7 @@ impl WasmModules {
                 tracing::debug!("instantiating wasm component: {name}...");
 
                 let (exports, instance) =
-                    module::Interface::instantiate(&mut store, &component, &mut linker)?;
+                    module::Interface::instantiate(&mut store, &component, &linker)?;
 
                 tracing::debug!("calling module's init function...");
                 exports.init(&mut store)?;

--- a/src/wasm/apis/sync_request.rs
+++ b/src/wasm/apis/sync_request.rs
@@ -34,7 +34,7 @@ impl sync_request::SyncRequest for SyncRequestApi {
             builder = builder.header(header.key, header.value);
         }
         if let Some(body) = req.body {
-            builder = builder.body(body.to_owned());
+            builder = builder.body(body);
         }
         let req = builder.build()?;
 


### PR DESCRIPTION
Before, the path where to put the wasm modules was hardcoded as the local wasm32 release directory in the modules subdir. Now, it still defaults to this, but it's possible to set it via an environment variable, and to set multiple ones by separating them with commas, as indicating in the example configuration file.