### PR TITLE
Higher-level interface to write Rust commands

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
 name = "pun"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "pun-bindings",
  "serde",
  "serde_json",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -128,6 +128,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libcommand"
+version = "0.1.0"
+
+[[package]]
 name = "linkify"
 version = "0.1.0"
 dependencies = [
@@ -242,7 +246,7 @@ dependencies = [
 name = "pun"
 version = "0.1.0"
 dependencies = [
- "anyhow",
+ "libcommand",
  "pun-bindings",
  "serde",
  "serde_json",

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "./openai",
 
     # Libs
+    "./libcommand",
     "./wit-log",
     "./wit-sync-request",
     "./wit-sys",
@@ -17,6 +18,7 @@ members = [
 ]
 
 [workspace.dependencies]
+libcommand = { path = "./libcommand" }
 wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }
 wit-log = { path = "./wit-log" }
 wit-sys = { path = "./wit-sys" }

--- a/modules/libcommand/Cargo.toml
+++ b/modules/libcommand/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "libcommand"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/modules/libcommand/src/lib.rs
+++ b/modules/libcommand/src/lib.rs
@@ -1,0 +1,114 @@
+//! High-level library providing a trait that, once implemented, hides the complexity of
+//! Wit bindings.
+//!
+//! There are a few problems at the moment:
+//!
+//! - It's not possible for a lib to implement a component interface, as it has to be the final
+//! binary implementing the component's interface; see also
+//! https://github.com/bytecodealliance/cargo-component/issues/75.
+//!
+//! - Because of that, I've had to put most of the code, including the whole `impl Interface for X`
+//! block, in the macro body. It's ugly and not practical for maintainability purposes.
+
+#[macro_export]
+macro_rules! impl_command {
+    ($ident:ident) => {
+        const _: () = {
+            type Wrapped = TrinityCommandWrapper<Component>;
+
+            /// Small wrapper which sole purpose is to work around the impossibility to have `impl Interface
+            /// for T where T: TrinityCommand`.
+            #[doc(hidden)]
+            pub struct TrinityCommandWrapper<T> {
+                _phantom: std::marker::PhantomData<T>,
+            }
+
+            impl<T> bindings::interface::Interface for TrinityCommandWrapper<T>
+            where
+                T: TrinityCommand,
+            {
+                fn init() {
+                    <T as TrinityCommand>::init();
+                }
+
+                fn help(topic: Option<String>) -> String {
+                    <T as TrinityCommand>::on_help(topic.as_deref())
+                }
+
+                fn on_msg(
+                    content: String,
+                    author_id: String,
+                    _author_name: String,
+                    _room: String,
+                ) -> Vec<bindings::interface::Message> {
+                    let mut client = CommandClient::default();
+                    <T as TrinityCommand>::on_msg(&mut client, &content);
+                    client
+                        .messages
+                        .into_iter()
+                        .map(|msg| bindings::interface::Message {
+                            content: msg,
+                            to: author_id.clone(),
+                        })
+                        .collect()
+                }
+
+                fn admin(cmd: String, author_id: String, room: String) -> Vec<bindings::interface::Message> {
+                    let mut client = CommandClient::default();
+                    <T as TrinityCommand>::on_admin(&mut client, &cmd, &room);
+                    client
+                        .messages
+                        .into_iter()
+                        .map(|msg| bindings::interface::Message {
+                            content: msg,
+                            to: author_id.clone(),
+                        })
+                        .collect()
+                }
+            }
+
+            bindings::export!(Wrapped);
+        };
+    };
+}
+
+#[derive(Default)]
+pub struct CommandClient {
+    pub messages: Vec<String>,
+}
+
+impl CommandClient {
+    /// Queues a message to be sent to someone.
+    pub fn respond(&mut self, msg: String) {
+        self.messages.push(msg);
+    }
+}
+
+pub trait TrinityCommand {
+    /// Code that will be called once during initialization of the command. This is a good time to
+    /// retrieve settings from the database and cache them locally, if needs be, or run any
+    /// initialization code that shouldn't run on every message later.
+    fn init() {}
+
+    /// Handle a message received in a room where the bot is present.
+    ///
+    /// The message isn't identified as a request for help or an admin command. Those are handled
+    /// respectively by `on_help` and `on_admin`.
+    ///
+    /// This should always be implemented, otherwise the command doesn't do anything.
+    fn on_msg(client: &mut CommandClient, content: &str);
+
+    /// Respond to a help request, for this specific command.
+    ///
+    /// If the topic is not set, then this should return a general description of the command, with
+    /// hints to the possible topics. If the topic is set, then this function should document
+    /// something related to the specific topic.
+    ///
+    /// This should always be implemented, at least to document what's the command's purpose.
+    fn on_help(_topic: Option<&str>) -> String;
+
+    /// Handle a message received by an admin, prefixed with the `!admin` subject.
+    ///
+    /// By default this does nothing, as admin commands are facultative.
+    fn on_admin(_client: &mut CommandClient, _command: &str, _room: &str) {}
+}

--- a/modules/libcommand/src/lib.rs
+++ b/modules/libcommand/src/lib.rs
@@ -53,7 +53,11 @@ macro_rules! impl_command {
                         .collect()
                 }
 
-                fn admin(cmd: String, author_id: String, room: String) -> Vec<bindings::interface::Message> {
+                fn admin(
+                    cmd: String,
+                    author_id: String,
+                    room: String,
+                ) -> Vec<bindings::interface::Message> {
                     let mut client = CommandClient::default();
                     <T as TrinityCommand>::on_admin(&mut client, &cmd, &room);
                     client

--- a/modules/pun/Cargo.toml
+++ b/modules/pun/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.66"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 
+libcommand.workspace = true
 wit-log.workspace = true
 wit-sync-request.workspace = true
 

--- a/modules/pun/Cargo.toml
+++ b/modules/pun/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.66"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 

--- a/modules/pun/src/lib.rs
+++ b/modules/pun/src/lib.rs
@@ -1,15 +1,6 @@
-use bindings::interface;
-
+use libcommand::*;
 use wit_log as log;
 use wit_sync_request;
-
-// TODO move to high-level library
-macro_rules! impl_command {
-    ($ident:ident) => {
-        type Wrapped = TrinityCommandWrapper<Component>;
-        bindings::export!(Wrapped);
-    };
-}
 
 struct Component;
 
@@ -48,122 +39,19 @@ impl TrinityCommand for Component {
         log::trace!("Called the init() method \\o/");
     }
 
-    fn on_msg(client: &mut CommandClient, msg: Message<'_>) {
-        match msg {
-            Message::Admin { command: _ } => {
-                client.respond("I don't have any admin commands".to_owned());
-            }
-            Message::Help { topic } => {
-                if topic == Some("toxic") {
-                    client.respond(
-                        "this is content fetched from a website on the internet, so this may be toxic!"
-                            .to_owned(),
-                    );
-                } else {
-                    client.respond("Get radioactive puns straight from the internet! (ask '!help pun toxic' for details on radioactivity)".to_owned());
-                }
-            }
-            Message::Message { content } => {
-                if let Some(content) = Self::get_pun(content) {
-                    client.respond(content);
-                }
-            }
+    fn on_msg(client: &mut CommandClient, msg: &str) {
+        if let Some(content) = Self::get_pun(msg) {
+            client.respond(content);
         }
+    }
+
+    fn on_help(topic: Option<&str>) -> String {
+        if topic == Some("toxic") {
+            "this is content fetched from a website on the internet, so this may be toxic!"
+        } else {
+            "Get radioactive puns straight from the internet! (ask '!help pun toxic' for details on radioactivity)"
+        }.to_owned()
     }
 }
 
 impl_command!(Component);
-
-// FRAMEWORK BITS, TODO move out to a shared library
-
-enum Message<'a> {
-    #[allow(unused)]
-    Admin {
-        command: &'a str,
-    },
-    Help {
-        topic: Option<&'a str>,
-    },
-    Message {
-        content: &'a str,
-    },
-}
-
-#[derive(Default)]
-struct CommandClient {
-    messages: Vec<String>,
-}
-
-impl CommandClient {
-    /// Queues a message to be sent to someone.
-    pub fn respond(&mut self, msg: String) {
-        self.messages.push(msg);
-    }
-}
-
-trait TrinityCommand {
-    fn init() {}
-    fn on_msg(client: &mut CommandClient, content: Message<'_>);
-}
-
-/// Small wrapper which sole purpose is to work around the impossibility to have `impl Interface
-/// for T where T: TrinityCommand`.
-struct TrinityCommandWrapper<T> {
-    _phantom: std::marker::PhantomData<T>,
-}
-
-impl<T> interface::Interface for TrinityCommandWrapper<T>
-where
-    T: TrinityCommand,
-{
-    fn init() {
-        <T as TrinityCommand>::init();
-    }
-
-    fn help(topic: Option<String>) -> String {
-        let mut client = CommandClient::default();
-        <T as TrinityCommand>::on_msg(
-            &mut client,
-            Message::Help {
-                topic: topic.as_deref(),
-            },
-        );
-        if !client.messages.is_empty() {
-            // TODO how to make it clear that only one message can be sent?
-            client.messages.remove(0)
-        } else {
-            String::from("<no help specified by the module>")
-        }
-    }
-
-    fn on_msg(
-        content: String,
-        author_id: String,
-        _author_name: String,
-        _room: String,
-    ) -> Vec<interface::Message> {
-        let mut client = CommandClient::default();
-        <T as TrinityCommand>::on_msg(&mut client, Message::Message { content: &content });
-        client
-            .messages
-            .into_iter()
-            .map(|msg| interface::Message {
-                content: msg,
-                to: author_id.clone(),
-            })
-            .collect()
-    }
-
-    fn admin(cmd: String, author_id: String, _room: String) -> Vec<interface::Message> {
-        let mut client = CommandClient::default();
-        <T as TrinityCommand>::on_msg(&mut client, Message::Admin { command: &cmd });
-        client
-            .messages
-            .into_iter()
-            .map(|msg| interface::Message {
-                content: msg,
-                to: author_id.clone(),
-            })
-            .collect()
-    }
-}


### PR DESCRIPTION
This is a small experiment I've started to make a higher-level API that's more pleasant to use to write commands in Rust. This would require custom glue code like this for each language, which might cause issues in terms of maintainability, but it's an interesting experiment to overcome the limits of what wit-bindgen allows to express.