### PR TITLE
Add `--locked` when installing cargo-component

### DIFF
--- a/modules/install-cargo-component.sh
+++ b/modules/install-cargo-component.sh
@@ -1,2 +1,2 @@
 #/bin/env sh
-cargo install --git https://github.com/bytecodealliance/cargo-component --rev 58b177bec15247b6f4d3a698c407e8c9266d9bec
+cargo install --locked --git https://github.com/bytecodealliance/cargo-component --rev 58b177bec15247b6f4d3a698c407e8c9266d9bec


### PR DESCRIPTION
so the pinned version is used by default.

This is sufficient to install `cargo-component` and be able to iterate again on the Rust modules. cc @ahal 